### PR TITLE
DDINTEGRA-11308

### DIFF
--- a/pdvsync/rotas/WTA - BUSCAR CLIENTES.json
+++ b/pdvsync/rotas/WTA - BUSCAR CLIENTES.json
@@ -80,6 +80,8 @@
 							"items": {
 								"*": {
 									"idExterno": "idExterno[]",
+									"idInterno": "items.[&1].idRetaguarda",
+									"tipoIdInterno": "PDVSYNC-CLIENTE",
 									"id": "items.[&1].idRetaguarda",
 									"name": "items.[&1].nome",
 									"active": "items.[&1].situacao",

--- a/pdvsync/rotas/WTA - BUSCAR ESTOQUE.json
+++ b/pdvsync/rotas/WTA - BUSCAR ESTOQUE.json
@@ -103,6 +103,8 @@
 							"items": {
 								"*": {
 									"idExterno": "idExterno[&1]",
+									"idInterno": "items[&1].idRetaguarda",
+								    "tipoIdInterno": "PDVSYNC-ESTOQUE",
 									"id_retaguarda": "items[&1].idRetaguarda",
 									"quantity": "items[&1].saldo",
 									"skuID_": "items[&1].codigoProduto",

--- a/pdvsync/rotas/WTA - BUSCAR FILIAIS COMPARTILHAMENTO.json
+++ b/pdvsync/rotas/WTA - BUSCAR FILIAIS COMPARTILHAMENTO.json
@@ -95,6 +95,8 @@
 							"items": {
 								"*": {
 									"idExterno": "idExterno",
+									"idInterno": "items[&1].[0].idRetaguarda",
+									"tipoIdInterno": "PDVSYNC-FILIAIS-COMPARTILHAMENTO",
 									"id": [
 										"items[&1].[0].idRetaguarda",
 										"items[&1].[0].idProprietario",

--- a/pdvsync/rotas/WTA - BUSCAR FILIAIS LOJAS.json
+++ b/pdvsync/rotas/WTA - BUSCAR FILIAIS LOJAS.json
@@ -95,6 +95,8 @@
 							"items": {
 								"*": {
 									"idExterno": "idExterno",
+									"idInterno": "items[&1].[0].idRetaguarda",
+									"tipoIdInterno": "PDVSYNC-FILIAIS-LOJA",
 									"id": [
 										"items[&1].[0].numeroLoja",
 										"items[&1].[0].codigoIdentificacaoLoja",

--- a/pdvsync/rotas/WTA - BUSCAR ICMS.json
+++ b/pdvsync/rotas/WTA - BUSCAR ICMS.json
@@ -94,6 +94,8 @@
 									"idExternoIcms": "items.[&1].[0].idExterno",
 									"idExternoSt": "items.[&1].[1].idExterno",
 									"idRetaguardaIcms": "items.[&1].[0].idRetaguarda",
+									"idInterno": "items.[&1].[0].idRetaguarda",
+									"tipoIdInterno": "PDVSYNC-ICMS",
 									"aliquota": "items.[&1].[0].aliquotaTributo",
 									"reducaoBaseCalculo": "items.[&1].[0].reducaoBaseCalculo",
 									"modalidadeVarejo": [

--- a/pdvsync/rotas/WTA - BUSCAR IMPOSTO NCM PDV.json
+++ b/pdvsync/rotas/WTA - BUSCAR IMPOSTO NCM PDV.json
@@ -96,6 +96,8 @@
 							"items": {
 								"*": {
 									"idExterno": "idExterno[&1]",
+									"idInterno": "items[&1].idRetaguarda",
+									"tipoIdInterno": "PDVSYNC-IMPOSTO-NCM",
 									"id": "items[&1].idRetaguarda",
 									"codigo_Ncm2": "items[&1].codigoNcm",
 									"codigoExcecao": "items[&1].codigoExcecao",

--- a/pdvsync/rotas/WTA - BUSCAR OPERADORA PDV.json
+++ b/pdvsync/rotas/WTA - BUSCAR OPERADORA PDV.json
@@ -92,6 +92,8 @@
 										}
 									},
 									"idExterno": "idExterno",
+									"idInterno": "items[&1].idRetaguarda",
+									"tipoIdInterno": "PDVSYNC-OPERADORA",
 									"codfilial": {
 										"99": {
 											"#{{MASTER_ID_PROPRIETARIO}}": "items[&3].idProprietario"

--- a/pdvsync/rotas/WTA - BUSCAR PIS COFINS.json
+++ b/pdvsync/rotas/WTA - BUSCAR PIS COFINS.json
@@ -84,6 +84,8 @@
 							"items": {
 								"*": {
 									"idExterno": "idExterno",
+									"idInterno": "items[&1].idRetaguarda",
+									"tipoIdInterno": "PDVSYNC-PIS-CONFINS",
 									"cst": [
 										"items[&1].cstPis",
 										"items[&1].cstCofins"

--- a/pdvsync/rotas/WTA - BUSCAR PLANOS DE PGTO.json
+++ b/pdvsync/rotas/WTA - BUSCAR PLANOS DE PGTO.json
@@ -117,6 +117,8 @@
 										}
 									},
 									"codigo": "items.[&1].[0].idRetaguarda",
+									"idInterno": "items.[&1].[0].idRetaguarda",
+									"tipoIdInterno": "PDVSYNC-PLANO-PAGAMENTO",
 									"codigoFilial": {
 										"99": {
 											"#{{MASTER_ID_PROPRIETARIO}}": "items.[&3].[0].idProprietario"

--- a/pdvsync/rotas/WTA - BUSCAR PRECO PRODUTO.json
+++ b/pdvsync/rotas/WTA - BUSCAR PRECO PRODUTO.json
@@ -60,6 +60,8 @@
 											"@(2,idExternoPreco)": "items[&3].[0].idExterno"
 										}
 									},
+									"idInterno": "items[&3].[0].idRetaguarda",
+									"tipoIdInterno": "PDVSYNC-PRECO-PRODUTO",
 									"erpReferenceKey": [
 										"items[&1].[0].codigoProduto"
 									],

--- a/pdvsync/rotas/WTA - BUSCAR PRODUTO PDV.json
+++ b/pdvsync/rotas/WTA - BUSCAR PRODUTO PDV.json
@@ -169,6 +169,8 @@
 										"@(1,icms[0].cst)": "items.[&2].cstIcms",
 										"codigoCest": "items.[&2].cest",
 										"idExterno": "idExterno",
+										"idInterno": "items.[&2].idRetaguarda",
+								        "tipoIdInterno": "PDVSYNC-PRODUTO",
 										"idRetaguarda": "items.[&2].idRetaguarda",
 										"situacao": {
 											"Inativo": {

--- a/pdvsync/rotas/WTA - BUSCAR STATUS PEDIDO.json
+++ b/pdvsync/rotas/WTA - BUSCAR STATUS PEDIDO.json
@@ -90,6 +90,8 @@
 							"items": {
 								"*": {
 									"idExterno": "idExterno[]",
+									"idInterno": "items.[&1].idRetaguarda",
+									"tipoIdInterno": "PDVSYNC-STATUS-PEDIDO",
 									"orderId": "items.[&1].idRetaguarda",
 									"branchId": "items.[&1].idProprietario",
 									"orderStatus": {

--- a/pdvsync/rotas/WTA - BUSCAR USUARIO OPERADOR.json
+++ b/pdvsync/rotas/WTA - BUSCAR USUARIO OPERADOR.json
@@ -87,6 +87,8 @@
 							"items": {
 								"*": {
 									"idExterno": "idExterno",
+									"idInterno": "items.[&1].idRetaguarda",
+								    "tipoIdInterno": "PDVSYNC-USUARIO-OPERADOR",
 									"matricula": "items.[&1].idRetaguarda",
 									"situacao": {
 										"ATIVO": {


### PR DESCRIPTION
1 - A alteração consiste em inserir "idExterno" = PCINTEGRACAOCORE.IDINTERNO e "tipoIdInterno" = PCINTEGRACAOCORE.TIPODOCUMENTO para gravar informações que faça correlação com o registro do Winthor para que possa ser rastreado posteriormente na PCINTEGRACAOCORE.

2 - O campo PCINTEGRACAOCORE.IDINTERNO nessa alteração vai receber sempre o "idRetaguarda" do registro.