### PR TITLE
DDINTEGRA-11308

### DIFF
--- a/pdvsync/rotas/WTA - BUSCAR CLIENTES.json
+++ b/pdvsync/rotas/WTA - BUSCAR CLIENTES.json
@@ -80,9 +80,8 @@
 							"items": {
 								"*": {
 									"idExterno": "idExterno[]",
-									"idInterno": "items.[&1].idRetaguarda",
-									"tipoIdInterno": "PDVSYNC-CLIENTE",
-									"id": "items.[&1].idRetaguarda",
+									"#PDVSYNC-CLIENTE": "items.[&1].tipoIdInterno",
+									"id": ["items.[&1].idRetaguarda", "items.[&1].idInterno"],
 									"name": "items.[&1].nome",
 									"active": "items.[&1].situacao",
 									"deliveryAddress": "items.[&1].endereco",

--- a/pdvsync/rotas/WTA - BUSCAR ESTOQUE.json
+++ b/pdvsync/rotas/WTA - BUSCAR ESTOQUE.json
@@ -102,10 +102,9 @@
 						"spec": {
 							"items": {
 								"*": {
-									"idExterno": "idExterno[&1]",
-									"idInterno": "items[&1].idRetaguarda",
-								    "tipoIdInterno": "PDVSYNC-ESTOQUE",
-									"id_retaguarda": "items[&1].idRetaguarda",
+									"idExterno": "idExterno[&1]",									
+									"#PDVSYNC-ESTOQUE": "items[&1].tipoIdInterno",
+									"id_retaguarda": ["items[&1].idRetaguarda", "items[&1].idInterno"],
 									"quantity": "items[&1].saldo",
 									"skuID_": "items[&1].codigoProduto",
 									"productId": "items[&1].idRetaguardaProduto"

--- a/pdvsync/rotas/WTA - BUSCAR FILIAIS COMPARTILHAMENTO.json
+++ b/pdvsync/rotas/WTA - BUSCAR FILIAIS COMPARTILHAMENTO.json
@@ -95,12 +95,12 @@
 							"items": {
 								"*": {
 									"idExterno": "idExterno",
-									"idInterno": "items[&1].[0].idRetaguarda",
-									"tipoIdInterno": "PDVSYNC-FILIAIS-COMPARTILHAMENTO",
+									"#PDVSYNC-FILIAIS-COMPARTILHAMENTO": "items[&1].[0].tipoIdInterno",		
 									"id": [
 										"items[&1].[0].idRetaguarda",
 										"items[&1].[0].idProprietario",
-										"items[&1].[0].idRetaguardaLoja"
+										"items[&1].[0].idRetaguardaLoja",
+										"items.[&2].idInterno"
 									],
 									"corporateName": "items[&1].[0].nomeCompartilhamento"
 								}

--- a/pdvsync/rotas/WTA - BUSCAR FILIAIS LOJAS.json
+++ b/pdvsync/rotas/WTA - BUSCAR FILIAIS LOJAS.json
@@ -95,12 +95,12 @@
 							"items": {
 								"*": {
 									"idExterno": "idExterno",
-									"idInterno": "items[&1].[0].idRetaguarda",
-									"tipoIdInterno": "PDVSYNC-FILIAIS-LOJA",
+									"#PDVSYNC-FILIAIS-LOJA": "items[&1].[0].tipoIdInterno",									
 									"id": [
 										"items[&1].[0].numeroLoja",
 										"items[&1].[0].codigoIdentificacaoLoja",
-										"items[&1].[0].idRetaguarda"
+										"items[&1].[0].idRetaguarda",
+										"items[&1].[0].idInterno"
 									],
 									"corporateName": [
 										"items[&1].[0].razaoSocial",

--- a/pdvsync/rotas/WTA - BUSCAR ICMS.json
+++ b/pdvsync/rotas/WTA - BUSCAR ICMS.json
@@ -92,10 +92,9 @@
 							"items": {
 								"*": {
 									"idExternoIcms": "items.[&1].[0].idExterno",
-									"idExternoSt": "items.[&1].[1].idExterno",
-									"idRetaguardaIcms": "items.[&1].[0].idRetaguarda",
-									"idInterno": "items.[&1].[0].idRetaguarda",
-									"tipoIdInterno": "PDVSYNC-ICMS",
+									"idExternoSt": "items.[&1].[1].idExterno",									
+									"#PDVSYNC-ICMS": "items.[&1].[0].tipoIdInterno",
+									"idRetaguardaIcms": ["items.[&1].[0].idRetaguarda", "items.[&1].[0].idInterno"],								
 									"aliquota": "items.[&1].[0].aliquotaTributo",
 									"reducaoBaseCalculo": "items.[&1].[0].reducaoBaseCalculo",
 									"modalidadeVarejo": [

--- a/pdvsync/rotas/WTA - BUSCAR IMPOSTO NCM PDV.json
+++ b/pdvsync/rotas/WTA - BUSCAR IMPOSTO NCM PDV.json
@@ -96,9 +96,8 @@
 							"items": {
 								"*": {
 									"idExterno": "idExterno[&1]",
-									"idInterno": "items[&1].idRetaguarda",
-									"tipoIdInterno": "PDVSYNC-IMPOSTO-NCM",
-									"id": "items[&1].idRetaguarda",
+									"#PDVSYNC-IMPOSTO-NCM": "items[&1].tipoIdInterno",
+									"id": ["items[&1].idRetaguarda", "items[&1].idInterno"],
 									"codigo_Ncm2": "items[&1].codigoNcm",
 									"codigoExcecao": "items[&1].codigoExcecao",
 									"aliquotaNacional": "items[&1].aliquotaNacional",

--- a/pdvsync/rotas/WTA - BUSCAR OPERADORA PDV.json
+++ b/pdvsync/rotas/WTA - BUSCAR OPERADORA PDV.json
@@ -77,7 +77,6 @@
 						"spec": {
 							"items": {
 								"*": {
-									"codcob": "items[&1].idRetaguarda",
 									"cobranca": "items[&1].descricao",
 									"codigoOperadora": "items[&1].administradora",
 									"codigoTef": "items[&1].codigoTef",
@@ -91,9 +90,9 @@
 											}
 										}
 									},
-									"idExterno": "idExterno",
-									"idInterno": "items[&1].idRetaguarda",
-									"tipoIdInterno": "PDVSYNC-OPERADORA",
+									"idExterno": "idExterno",									
+									"#PDVSYNC-OPERADORA": "items[&1].tipoIdInterno",
+									"codcob": ["items[&1].idRetaguarda", "items[&1].idInterno"],								
 									"codfilial": {
 										"99": {
 											"#{{MASTER_ID_PROPRIETARIO}}": "items[&3].idProprietario"

--- a/pdvsync/rotas/WTA - BUSCAR PIS COFINS.json
+++ b/pdvsync/rotas/WTA - BUSCAR PIS COFINS.json
@@ -83,16 +83,15 @@
 						"spec": {
 							"items": {
 								"*": {
-									"idExterno": "idExterno",
-									"idInterno": "items[&1].idRetaguarda",
-									"tipoIdInterno": "PDVSYNC-PIS-CONFINS",
+									"idExterno": "idExterno",							
+									"#PDVSYNC-PIS-CONFINS": "items[&1].tipoIdInterno",
+									"codTribPisCofins": ["items[&1].idRetaguarda", "items[&1].idInterno"],								
 									"cst": [
 										"items[&1].cstPis",
 										"items[&1].cstCofins"
 									],
 									"aliquotaPis": "items[&1].aliquotaPis",
-									"aliquotaCofins": "items[&1].aliquotaCofins",
-									"codTribPisCofins": "items[&1].idRetaguarda"
+									"aliquotaCofins": "items[&1].aliquotaCofins"
 								}
 							}
 						}

--- a/pdvsync/rotas/WTA - BUSCAR PLANOS DE PGTO.json
+++ b/pdvsync/rotas/WTA - BUSCAR PLANOS DE PGTO.json
@@ -116,9 +116,8 @@
 											"@1": "items.[&3].[0].numeroMaximoParcelas"
 										}
 									},
-									"codigo": "items.[&1].[0].idRetaguarda",
-									"idInterno": "items.[&1].[0].idRetaguarda",
-									"tipoIdInterno": "PDVSYNC-PLANO-PAGAMENTO",
+									"#PDVSYNC-PLANO-PAGAMENTO": "items.[&1].[0].tipoIdInterno",
+									"codigo": ["items.[&1].[0].idRetaguarda", "items.[&1].[0].idInterno"],									
 									"codigoFilial": {
 										"99": {
 											"#{{MASTER_ID_PROPRIETARIO}}": "items.[&3].[0].idProprietario"

--- a/pdvsync/rotas/WTA - BUSCAR PRECO PRODUTO.json
+++ b/pdvsync/rotas/WTA - BUSCAR PRECO PRODUTO.json
@@ -52,16 +52,16 @@
 								"*": {
 									"origin": {
 										"357": {
-											"@(2,idRetaguarda357)": "items[&3].[0].idRetaguarda",
-											"@(2,idExternoPreco357)": "items[&3].[0].idExterno"
+											"@(2,idExternoPreco357)": "items[&3].[0].idExterno",
+											"#PDVSYNC-PRECO-PRODUTO": "items[&3].[0].tipoIdInterno",
+											"@(2,idRetaguarda357)": ["items[&3].[0].idRetaguarda", "items[&3].[0].idInterno"]											
 										},
 										"*": {
-											"@(2,skuId)": "items[&3].[0].idRetaguarda",
-											"@(2,idExternoPreco)": "items[&3].[0].idExterno"
+											"@(2,idExternoPreco)": "items[&3].[0].idExterno",
+											"#PDVSYNC-PRECO-PRODUTO": "items[&3].[0].tipoIdInterno",
+											"@(2,skuId)": ["items[&3].[0].idRetaguarda", "items[&3].[0].idInterno"]											
 										}
 									},
-									"idInterno": "items[&3].[0].idRetaguarda",
-									"tipoIdInterno": "PDVSYNC-PRECO-PRODUTO",
 									"erpReferenceKey": [
 										"items[&1].[0].codigoProduto"
 									],

--- a/pdvsync/rotas/WTA - BUSCAR PRODUTO PDV.json
+++ b/pdvsync/rotas/WTA - BUSCAR PRODUTO PDV.json
@@ -169,9 +169,8 @@
 										"@(1,icms[0].cst)": "items.[&2].cstIcms",
 										"codigoCest": "items.[&2].cest",
 										"idExterno": "idExterno",
-										"idInterno": "items.[&2].idRetaguarda",
-								        "tipoIdInterno": "PDVSYNC-PRODUTO",
-										"idRetaguarda": "items.[&2].idRetaguarda",
+										"#PDVSYNC-PRODUTO": "items.[&2].tipoIdInterno",
+										"idRetaguarda": ["items.[&2].idRetaguarda", "items.[&2].idInterno"],
 										"situacao": {
 											"Inativo": {
 												"#0": "items.[&4].situacao"

--- a/pdvsync/rotas/WTA - BUSCAR STATUS PEDIDO.json
+++ b/pdvsync/rotas/WTA - BUSCAR STATUS PEDIDO.json
@@ -89,10 +89,9 @@
 						"spec": {
 							"items": {
 								"*": {
-									"idExterno": "idExterno[]",
-									"idInterno": "items.[&1].idRetaguarda",
-									"tipoIdInterno": "PDVSYNC-STATUS-PEDIDO",
-									"orderId": "items.[&1].idRetaguarda",
+									"idExterno": "idExterno[]",									
+									"#PDVSYNC-STATUS-PEDIDO": "items.[&2].tipoIdInterno",
+									"orderId": ["items.[&1].idRetaguarda", "items.[&1].idInterno"],
 									"branchId": "items.[&1].idProprietario",
 									"orderStatus": {
 										"C": {

--- a/pdvsync/rotas/WTA - BUSCAR USUARIO OPERADOR.json
+++ b/pdvsync/rotas/WTA - BUSCAR USUARIO OPERADOR.json
@@ -86,10 +86,9 @@
 						"spec": {
 							"items": {
 								"*": {
-									"idExterno": "idExterno",
-									"idInterno": "items.[&1].idRetaguarda",
-								    "tipoIdInterno": "PDVSYNC-USUARIO-OPERADOR",
-									"matricula": "items.[&1].idRetaguarda",
+									"idExterno": "idExterno",									
+									"#PDVSYNC-USUARIO-OPERADOR": "items.[&1].tipoIdInterno",
+									"matricula": ["items.[&1].idRetaguarda", "items.[&1].idInterno"],
 									"situacao": {
 										"ATIVO": {
 											"#1": "items.[&3].situacao"


### PR DESCRIPTION
1 - A alteração consiste em inserir "idExterno" = PCINTEGRACAOCORE.IDINTERNO e "tipoIdInterno" = PCINTEGRACAOCORE.TIPODOCUMENTO para gravar informações que faça correlação com o registro do Winthor para que possa ser rastreado posteriormente na PCINTEGRACAOCORE.

2 - O campo PCINTEGRACAOCORE.IDINTERNO nessa alteração vai receber sempre o "idRetaguarda" do registro.