### PR TITLE
DDINTEGRA-11899

### DIFF
--- a/pdvsync/rotas/PDVSYNC - BUSCAR VENDAS.json
+++ b/pdvsync/rotas/PDVSYNC - BUSCAR VENDAS.json
@@ -96,6 +96,8 @@
                                         }
                                     },
                                     "idExterno": "=concat('pdvsync-vendamensagem-',@(1,id),'-',@(1,dataAtualizacao))",
+									"idInterno":"=concat('', @(1,chaveAcesso))",
+							        "tipoIdInterno":"PDVSYNC-MONITOR-VENDA",
                                     "idPdv": "@(1,id)",
                                     "numeroCupom": "@(1,conteudo.Coo)"
                                 }
@@ -323,6 +325,14 @@
                                         "idExterno",
                                         "items.[&1].idExterno"
                                     ],
+									"idInterno": [
+                                        "idInterno",
+                                        "items.[&1].idInterno"
+                                    ],
+									"tipoIdInterno": [
+                                        "tipoIdInterno",
+                                        "items.[&1].tipoIdInterno"
+                                    ],									
                                     "idPdv": "items.[&1].idPdv",
                                     "numeroCupom": [
                                         "items.[&1].numCupom",


### PR DESCRIPTION
Alterar a rota PDVSYNC - BUSCAR VENDAS que busca a venda para gravar os campos "tipoIdInterno" = TIPODOCUMENTO e "idInterno" = IDINTERNO (Chave da venda).