### PR TITLE
DDINTEGRA-12118

### DIFF
--- a/pdvsync/rotas/WTA - BUSCAR PRODUTO PDV.json
+++ b/pdvsync/rotas/WTA - BUSCAR PRODUTO PDV.json
@@ -96,6 +96,11 @@
 													"=concat(@(3,descricao),' - ',@(1,embalagem))"
 												]
 											}
+										},
+										"produtoKits": {
+											"*": {
+												"idRetaguarda": "=concat(@(1,codigoDeBarraItemKit),'-',@(1,idRetaguardaProdutoKit))"
+											}
 										}
 									},
 									"ncm": {
@@ -252,6 +257,7 @@
 										},
 										"produtoKits": {
 											"*": {
+												"idRetaguarda": "items.[&4].produtoKits[&1].idRetaguarda",
 												"idRetaguardaProduto": "items.[&4].produtoKits[&1].idRetaguardaProduto",
 												"idRetaguardaProdutoKit": "items.[&4].produtoKits[&1].idRetaguardaProdutoKit",
 												"descricao": "items.[&4].produtoKits[&1].descricao",


### PR DESCRIPTION
Na rota do WSH chamada (WTA - BUSCAR PRODUTO PDV) foi realizado uma alteração para gerar o campo de "idRetaguarda" composta por dois campos da API : "produtoKits.codigoDeBarraItemKit" + "produtoKits.idRetaguardaProdutoKit" onde essa alteração já foi realizada na ultima versão da API em questão.