### PR TITLE
Ajuste para alterar o modo "operation" do jolt para "custom-totvs"

### DIFF
--- a/pdvsync/rotas/PDVSYNC - BUSCAR MOVIMENTACOES CAIXA.json
+++ b/pdvsync/rotas/PDVSYNC - BUSCAR MOVIMENTACOES CAIXA.json
@@ -50,7 +50,7 @@
 				"nome": "LAYOUTTRANSFORMACAO",
 				"valor": [
 					{
-						"operation": "br.com.totvs.integracao.winthosmarthube.infra.jolt.custom.JoltModifyCustomOperation",
+						"operation": "custom-totvs",
 						"spec": {
 							"data": {
 								"*": {

--- a/pdvsync/rotas/PDVSYNC - BUSCAR PEDIDOS CANCELADA.json
+++ b/pdvsync/rotas/PDVSYNC - BUSCAR PEDIDOS CANCELADA.json
@@ -46,7 +46,7 @@
 				"nome": "LAYOUTTRANSFORMACAO",
 				"valor": [
 					{
-						"operation": "br.com.totvs.integracao.winthosmarthube.infra.jolt.custom.JoltModifyCustomOperation",
+						"operation": "custom-totvs",
 						"spec": {
 							"data": {
 								"*": {

--- a/pdvsync/rotas/PDVSYNC - BUSCAR PEDIDOS RECEBIDO.json
+++ b/pdvsync/rotas/PDVSYNC - BUSCAR PEDIDOS RECEBIDO.json
@@ -50,7 +50,7 @@
 				"nome": "LAYOUTTRANSFORMACAO",
 				"valor": [
 					{
-						"operation": "br.com.totvs.integracao.winthosmarthube.infra.jolt.custom.JoltModifyCustomOperation",
+						"operation": "custom-totvs",
 						"spec": {
 							"data": {
 								"*": {

--- a/pdvsync/rotas/PDVSYNC - BUSCAR VENDAS.json
+++ b/pdvsync/rotas/PDVSYNC - BUSCAR VENDAS.json
@@ -51,7 +51,7 @@
                 "nome": "LAYOUTTRANSFORMACAO",
                 "valor": [
                     {
-                        "operation": "br.com.totvs.integracao.winthosmarthube.infra.jolt.custom.JoltModifyCustomOperation",
+                        "operation": "custom-totvs",
                         "spec": {
                             "data": {
                                 "*": {


### PR DESCRIPTION
Ajuste para alterar o modo "operation" do jolt de "br.com.totvs.integracao.winthosmarthube.infra.jolt.custom.JoltModifyCustomOperation" para "custom-totvs" das seguintes rotas: PDVSYNC - BUSCAR MOVIMENTACOES CAIXA.json, PDVSYNC - BUSCAR PEDIDOS CANCELADA.json, PDVSYNC - BUSCAR PEDIDOS RECEBIDO.json e PDVSYNC - BUSCAR VENDAS.json