### PR TITLE
DDWMISSI-244 - Inclusão de um item no array com status 99 para garant…

### DIFF
--- a/pdvsync/rotas/PDVSYNC - CONSULTAR STATUS LOTE.json
+++ b/pdvsync/rotas/PDVSYNC - CONSULTAR STATUS LOTE.json
@@ -59,6 +59,28 @@
 				"nome": "LAYOUTTRANSFORMACAO",
 				"valor": [
 					  {
+						"operation": "default",
+						"spec": {
+						  "data": {
+							"temp": {
+							  "status": 99,
+							  "errosIdentificados": []
+							}
+						  }
+						}
+						},
+					  {
+						"operation": "shift",
+						"spec": {
+						  "data": {
+							"lote": "data.lote",
+							"loteOrigem": "data.loteOrigem",
+							"lojaLotes": "data.lojaLotes",
+							"temp": "data.lojaLotes[]"
+						  }
+						}
+					  },				
+					  {
 						"operation": "shift",
 						"spec": {
 						  "data": {


### PR DESCRIPTION
…ir que o JOLT gere o status como um array quando existir somente uma filial e consiga usar a função min() para obter o menor status