### PR TITLE
DDWMISSI-860

### DIFF
--- a/pdvsync/rotas/WTA - BUSCAR CLIENTES.json
+++ b/pdvsync/rotas/WTA - BUSCAR CLIENTES.json
@@ -71,7 +71,8 @@
 							   "telefone_entrega":"=join('', @(1,telefone_entrega_array))",
 							   "idExterno":"=concat('pdvsync-cliente-',@(1,id),'-',@(1,lastChange))",
 							   "idInterno":"=concat('', @(1,id))",
-							   "tipoIdInterno":"PDVSYNC-CLIENTE"
+							   "tipoIdInterno":"PDVSYNC-CLIENTE",
+							   "profissionalRetaguarda": "=concat('PRO-',@(1,professionalId))"
 							}
 						 }
 					  }
@@ -118,7 +119,7 @@
 							   },
 							   "createDate":"items.[&1].dataCadastro",
 							   "deliveryAddressNumber":"items.[&1].numero",
-							   "professionalId":"items.[&1].IdProfissionalRetaguarda"
+							   "profissionalRetaguarda": "items.[&1].IdProfissionalRetaguarda"
 							}
 						 }
 					  }


### PR DESCRIPTION
Alterado para inserir o padrão de string "PRO-" no campo de IdProfissionalRetaguarda pois no envio de profissional foi adotado esse padrão para o idinterno. No PDVOmni essa ligação será feito por chave estrangeira e caso não esteja igual a coluna fica null.