### PR TITLE
hotfix/DWSHWTNG-1056-confirmacao-venda-develop

### DIFF
--- a/pdvsync/rotas/PDVSYNC - BUSCAR VENDAS.json
+++ b/pdvsync/rotas/PDVSYNC - BUSCAR VENDAS.json
@@ -3,7 +3,7 @@
         "campos": [
             {
                 "nome": "SOMENTEATUALIZARINTEGRACAOCORE",
-                "valor": "N"
+                "valor": "S"
             },
             {
                 "nome": "ID",


### PR DESCRIPTION
- Atualizada a rota de busca de vendas para o campo SOMENTEATUALIZARINTEGRACAOCORE = S, pois quando existir o idExterno deve atualizar o registro e reprocessar para assim a venda sair da fila novamente.