### PR TITLE
Padronização de campos da rota buscar ramo atividade conforme contrato do integrador

### DIFF
--- a/pdvsync/rotas/WTA - BUSCAR RAMO ATIVIDADE.json
+++ b/pdvsync/rotas/WTA - BUSCAR RAMO ATIVIDADE.json
@@ -109,9 +109,21 @@
 							"_attr_access": "items",
 							"items[]": {
 								"*": {
-									"idInquilino": "{{ID_INQUILINO}}",
-									"idProprietario": "{{MASTER_ID_PROPRIETARIO}}",
-									"loteOrigem": "{{LOTE_ORIGEM}}"
+									"IdInquilino": "{{ID_INQUILINO}}",
+									"IdProprietario": "{{MASTER_ID_PROPRIETARIO}}",
+									"LoteOrigem": "{{LOTE_ORIGEM}}"
+								}
+							}
+						}
+					},
+					{
+						"operation": "modify-overwrite-beta",
+						"spec": {
+							"items": {
+							"*": {
+								"IdRetaguarda": "=toString",
+								"IdRetaguardaAtividadePrincipal": "=toString",
+								"Situacao": "=toInteger"
 								}
 							}
 						}


### PR DESCRIPTION
Atualiza nomenclatura de campos para PascalCase
Adiciona conversão de tipos (Situacao para int, IDs para string)
[
{
"IdRetaguarda": "1",
"Descricao": "Lojinha 4",
"PercentualTaxa": 3,
"IdRetaguardaAtividadePrincipal": "2",
"DataCadastro": "2024-10-18T09:17:18",
"DataAtualizacao": "2025-09-09T17:22:01",
"Situacao": 1,
"IdInquilino": "{{ID_INQUILINO}}",
"IdProprietario": "{{MASTER_ID_PROPRIETARIO}}",
"LoteOrigem": "{{LOTE_ORIGEM}}"
}
]