### PR TITLE
DDWMISSI-4515 | Alteração de API para multi filial - Operadora PDV

### DIFF
--- a/pdvsync/rotas/WTA - BUSCAR OPERADORA PDV.json
+++ b/pdvsync/rotas/WTA - BUSCAR OPERADORA PDV.json
@@ -52,6 +52,10 @@
 								{
 									"key": "tipoOperacao",
 									"value": "01, 02"
+								},
+								{
+									"key": "codfilial",
+									"value": "{{FILIAL}}"
 								}
 							]
 						}

--- a/pdvsync/variaveis/WTA - Buscar Operadora PDV-{{FILIAL}}.json
+++ b/pdvsync/variaveis/WTA - Buscar Operadora PDV-{{FILIAL}}.json
@@ -28,7 +28,7 @@
 			},
 			{
 				"nome": "VALOR",
-				"valor": "ADICIONAR_FILIAL"
+				"valor": "99"
 			},
 			{
 				"nome": "CODEMPALTER",


### PR DESCRIPTION
### 📝 Contexto

Ajuste no layout da rota `WTA - BUSCAR OPERADORA PDV` para permitir a exportação de dados em formato multi filial no cadastro de operadoras do PDV.

### 🛠 Alterações Realizadas

O layout da rota `WTA - BUSCAR OPERADORA PDV` foi alterada para aceitar parâmetros em formato multi filial (ex: 1,2). Foi implementada a regra de negócio que define a filial 99 como padrão: caso o cliente atualize o layout e não altere o parâmetro `{{FILIAL}}`, o layout assumirá automaticamente o valor 99, continuando a enviar todas as filiais.

### 📚 Documentação e Evidências

Evidências de Desenvolvimento: [Link](https://drive.google.com/file/d/10IHE_lR0ZwDb8JSKfl_HojNfyfrwgZvU/view?usp=sharing)