### PR TITLE
DDWMISSI-4639 - Parametrização de Variáveis da Integração PDVSYNC no Wizard do WSH

### DIFF
--- a/pdvsync/variaveis/PDVSYNC - Atualizar status cliente-{{ID_INQUILINO}}.json
+++ b/pdvsync/variaveis/PDVSYNC - Atualizar status cliente-{{ID_INQUILINO}}.json
@@ -1,40 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": ""
-			},
-			{
-				"nome": "ID",
-				"valor": "PDVSYNC - ATUALIZAR STATUS CLIENTE-{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "BODY"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "PDVSYNC - ATUALIZAR STATUS CLIENTE"
-			},
-			{
-				"nome": "VALOR",
-				"valor":"ADICIONAR_INQUILINO"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			}
-		]
-	}
-	
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": ""
+      },
+      {
+        "nome": "ID",
+        "valor": "PDVSYNC - ATUALIZAR STATUS CLIENTE-{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "BODY"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "PDVSYNC - ATUALIZAR STATUS CLIENTE"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_INQUILINO"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 1
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Número Inquilo"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/PDVSYNC - Buscar Pedidos CANCELADA-{{ID_INQUILINO}}.json
+++ b/pdvsync/variaveis/PDVSYNC - Buscar Pedidos CANCELADA-{{ID_INQUILINO}}.json
@@ -1,39 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": ""
-			},
-			{
-				"nome": "ID",
-				"valor": "PDVSYNC - BUSCAR PEDIDOS CANCELADA-{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "BODY"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "PDVSYNC - BUSCAR PEDIDOS CANCELADA"
-			},
-			{
-				"nome": "VALOR",
-				"valor":"ADICIONAR_INQUILINO"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			}
-		]
-	}
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": ""
+      },
+      {
+        "nome": "ID",
+        "valor": "PDVSYNC - BUSCAR PEDIDOS CANCELADA-{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "BODY"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "PDVSYNC - BUSCAR PEDIDOS CANCELADA"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_INQUILINO"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 4
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Número Inquilo"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/PDVSYNC - Buscar Pedidos RECEBIDO-{{ID_INQUILINO}}.json
+++ b/pdvsync/variaveis/PDVSYNC - Buscar Pedidos RECEBIDO-{{ID_INQUILINO}}.json
@@ -1,39 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": ""
-			},
-			{
-				"nome": "ID",
-				"valor": "PDVSYNC - BUSCAR PEDIDOS RECEBIDO-{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "BODY"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "PDVSYNC - BUSCAR PEDIDOS RECEBIDO"
-			},
-			{
-				"nome": "VALOR",
-				"valor":"ADICIONAR_INQUILINO"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			}
-		]
-	}
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": ""
+      },
+      {
+        "nome": "ID",
+        "valor": "PDVSYNC - BUSCAR PEDIDOS RECEBIDO-{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "BODY"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "PDVSYNC - BUSCAR PEDIDOS RECEBIDO"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_INQUILINO"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 5
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Número Inquilo"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/PDVSYNC - Buscar clientes-{{ID_INQUILINO}}.json
+++ b/pdvsync/variaveis/PDVSYNC - Buscar clientes-{{ID_INQUILINO}}.json
@@ -1,40 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": ""
-			},
-			{
-				"nome": "ID",
-				"valor": "PDVSYNC - BUSCAR CLIENTES-{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "BODY"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "PDVSYNC - BUSCAR CLIENTES"
-			},
-			{
-				"nome": "VALOR",
-				"valor":"ADICIONAR_INQUILINO"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			}
-		]
-	}
-	
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": ""
+      },
+      {
+        "nome": "ID",
+        "valor": "PDVSYNC - BUSCAR CLIENTES-{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "BODY"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "PDVSYNC - BUSCAR CLIENTES"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_INQUILINO"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 2
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Número Inquilo"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/PDVSYNC - Buscar movimentacoes caixa-{{ID_INQUILINO}}.json
+++ b/pdvsync/variaveis/PDVSYNC - Buscar movimentacoes caixa-{{ID_INQUILINO}}.json
@@ -1,39 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": ""
-			},
-			{
-				"nome": "ID",
-				"valor": "PDVSYNC - BUSCAR MOVIMENTACOES CAIXA-{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "BODY"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "PDVSYNC - BUSCAR MOVIMENTACOES CAIXA"
-			},
-			{
-				"nome": "VALOR",
-				"valor": "ADICIONAR_INQUILINO"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			}
-		]
-	}
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": ""
+      },
+      {
+        "nome": "ID",
+        "valor": "PDVSYNC - BUSCAR MOVIMENTACOES CAIXA-{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "BODY"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "PDVSYNC - BUSCAR MOVIMENTACOES CAIXA"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_INQUILINO"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 3
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Número Inquilo"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/PDVSYNC - Buscar vendas-{{ID_INQUILINO}}.json
+++ b/pdvsync/variaveis/PDVSYNC - Buscar vendas-{{ID_INQUILINO}}.json
@@ -1,39 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": ""
-			},
-			{
-				"nome": "ID",
-				"valor": "PDVSYNC - BUSCAR VENDAS-{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "BODY"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "PDVSYNC - BUSCAR VENDAS"
-			},
-			{
-				"nome": "VALOR",
-				"valor":"ADICIONAR_INQUILINO"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			}
-		]
-	}
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": ""
+      },
+      {
+        "nome": "ID",
+        "valor": "PDVSYNC - BUSCAR VENDAS-{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "BODY"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "PDVSYNC - BUSCAR VENDAS"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_INQUILINO"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 6
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Número Inquilo"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/PDVSYNC - Consultar lote-{{ID_INQUILINO}}.json
+++ b/pdvsync/variaveis/PDVSYNC - Consultar lote-{{ID_INQUILINO}}.json
@@ -1,39 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": ""
-			},
-			{
-				"nome": "ID",
-				"valor": "PDVSYNC - CONSULTAR LOTE-{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "BODY"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "PDVSYNC - CONSULTAR LOTE"
-			},
-			{
-				"nome": "VALOR",
-				"valor":"ADICIONAR_INQUILINO"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			}
-		]
-	}
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": ""
+      },
+      {
+        "nome": "ID",
+        "valor": "PDVSYNC - CONSULTAR LOTE-{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "BODY"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "PDVSYNC - CONSULTAR LOTE"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_INQUILINO"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 7
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Número Inquilo"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/PDVSYNC - Consultar status lote-{{FILIAL}}.json
+++ b/pdvsync/variaveis/PDVSYNC - Consultar status lote-{{FILIAL}}.json
@@ -1,43 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": ""
-			},
-			{
-				"nome": "ID",
-				"valor": "PDVSYNC - CONSULTAR STATUS LOTE-{{FILIAL}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{FILIAL}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "PARAMS"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "PDVSYNC - CONSULTAR STATUS LOTE"
-			},
-			{
-				"nome": "VALOR",
-				"valor":"ADICIONAR_FILIAL"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			},
-			{
-                "nome": "VISIVELWIZARD",
-                "valor": "S"
-            }
-		]
-	}
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": ""
+      },
+      {
+        "nome": "ID",
+        "valor": "PDVSYNC - CONSULTAR STATUS LOTE-{{FILIAL}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{FILIAL}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "PARAMS"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "PDVSYNC - CONSULTAR STATUS LOTE"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_FILIAL"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 8
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Número da Filial"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/PDVSYNC - Consultar status lote-{{ID_INQUILINO}}.json
+++ b/pdvsync/variaveis/PDVSYNC - Consultar status lote-{{ID_INQUILINO}}.json
@@ -1,39 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": ""
-			},
-			{
-				"nome": "ID",
-				"valor": "PDVSYNC - CONSULTAR STATUS LOTE-{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "BODY"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "PDVSYNC - CONSULTAR STATUS LOTE"
-			},
-			{
-				"nome": "VALOR",
-				"valor":"ADICIONAR_INQUILINO"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			}
-		]
-	}
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": ""
+      },
+      {
+        "nome": "ID",
+        "valor": "PDVSYNC - CONSULTAR STATUS LOTE-{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "BODY"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "PDVSYNC - CONSULTAR STATUS LOTE"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_INQUILINO"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 9
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Número Inquilo"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/PDVSYNC - Criar variavel temporaria-{{INQUILINO}}.json
+++ b/pdvsync/variaveis/PDVSYNC - Criar variavel temporaria-{{INQUILINO}}.json
@@ -1,39 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": ""
-			},
-			{
-				"nome": "ID",
-				"valor": "PDVSYNC - CRIAR VARIAVEL TEMPORARIA-{{INQUILINO}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{INQUILINO}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "PARAMS"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "PDVSYNC - CRIAR VARIAVEL TEMPORARIA"
-			},
-			{
-				"nome": "VALOR",
-				"valor":"ADICIONAR_INQUILINO"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			}
-		]
-	}
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": ""
+      },
+      {
+        "nome": "ID",
+        "valor": "PDVSYNC - CRIAR VARIAVEL TEMPORARIA-{{INQUILINO}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{INQUILINO}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "PARAMS"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "PDVSYNC - CRIAR VARIAVEL TEMPORARIA"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_INQUILINO"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 10
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Número Inquilo"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/PDVSYNC - ENVIAR PIS COFINS-{{ID_INQUILINO}}.json
+++ b/pdvsync/variaveis/PDVSYNC - ENVIAR PIS COFINS-{{ID_INQUILINO}}.json
@@ -1,39 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": ""
-			},
-			{
-				"nome": "ID",
-				"valor": "PDVSYNC - ENVIAR PIS COFINS-{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "BODY"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "PDVSYNC - ENVIAR PIS COFINS"
-			},
-			{
-				"nome": "VALOR",
-				"valor":"ADICIONAR_INQUILINO"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			}
-		]
-	}
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": ""
+      },
+      {
+        "nome": "ID",
+        "valor": "PDVSYNC - ENVIAR PIS COFINS-{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "BODY"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "PDVSYNC - ENVIAR PIS COFINS"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_INQUILINO"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 23
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Número Inquilo"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/PDVSYNC - Encerrar variavel temporaria-{{INQUILINO}}.json
+++ b/pdvsync/variaveis/PDVSYNC - Encerrar variavel temporaria-{{INQUILINO}}.json
@@ -1,39 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": ""
-			},
-			{
-				"nome": "ID",
-				"valor": "PDVSYNC - ENCERRAR VARIAVEL TEMPORARIA-{{INQUILINO}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{INQUILINO}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "PARAMS"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "PDVSYNC - ENCERRAR VARIAVEL TEMPORARIA"
-			},
-			{
-				"nome": "VALOR",
-				"valor":"ADICIONAR_INQUILINO"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			}
-		]
-	}
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": ""
+      },
+      {
+        "nome": "ID",
+        "valor": "PDVSYNC - ENCERRAR VARIAVEL TEMPORARIA-{{INQUILINO}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{INQUILINO}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "PARAMS"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "PDVSYNC - ENCERRAR VARIAVEL TEMPORARIA"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_INQUILINO"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 11
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Número Inquilo"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/PDVSYNC - Envia status pedido-{{ID_INQUILINO}}.json
+++ b/pdvsync/variaveis/PDVSYNC - Envia status pedido-{{ID_INQUILINO}}.json
@@ -1,39 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": ""
-			},
-			{
-				"nome": "ID",
-				"valor": "PDVSYNC - ENVIA STATUS PEDIDO-{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "BODY"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "PDVSYNC - ENVIA STATUS PEDIDO"
-			},
-			{
-				"nome": "VALOR",
-				"valor":"ADICIONAR_INQUILINO"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			}
-		]
-	}
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": ""
+      },
+      {
+        "nome": "ID",
+        "valor": "PDVSYNC - ENVIA STATUS PEDIDO-{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "BODY"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "PDVSYNC - ENVIA STATUS PEDIDO"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_INQUILINO"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 12
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Número Inquilo"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/PDVSYNC - Enviar CFOP Reforma Tributaria-{{ID_INQUILINO}}.json
+++ b/pdvsync/variaveis/PDVSYNC - Enviar CFOP Reforma Tributaria-{{ID_INQUILINO}}.json
@@ -1,40 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": ""
-			},
-			{
-				"nome": "ID",
-				"valor": "PDVSYNC - ENVIAR CFOP REFORMA TRIBUTARIA-{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "BODY"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "PDVSYNC - ENVIAR CFOP REFORMA TRIBUTARIA"
-			},
-			{
-				"nome": "VALOR",
-				"valor":"ADICIONAR_INQUILINO"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			}
-		]
-	}
-	
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": ""
+      },
+      {
+        "nome": "ID",
+        "valor": "PDVSYNC - ENVIAR CFOP REFORMA TRIBUTARIA-{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "BODY"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "PDVSYNC - ENVIAR CFOP REFORMA TRIBUTARIA"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_INQUILINO"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 13
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Número Inquilo"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/PDVSYNC - Enviar Desconto e Acrescimo-{{ID_INQUILINO}}.json
+++ b/pdvsync/variaveis/PDVSYNC - Enviar Desconto e Acrescimo-{{ID_INQUILINO}}.json
@@ -1,39 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": ""
-			},
-			{
-				"nome": "ID",
-				"valor": "PDVSYNC - ENVIAR DESCONTO E ACRESCIMO-{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "BODY"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "PDVSYNC - ENVIAR DESCONTO E ACRESCIMO"
-			},
-			{
-				"nome": "VALOR",
-				"valor":"ADICIONAR_INQUILINO"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			}
-		]
-	}
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": ""
+      },
+      {
+        "nome": "ID",
+        "valor": "PDVSYNC - ENVIAR DESCONTO E ACRESCIMO-{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "BODY"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "PDVSYNC - ENVIAR DESCONTO E ACRESCIMO"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_INQUILINO"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 15
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Número Inquilo"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/PDVSYNC - Enviar Estoque-{{ID_INQUILINO}}.json
+++ b/pdvsync/variaveis/PDVSYNC - Enviar Estoque-{{ID_INQUILINO}}.json
@@ -1,39 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": ""
-			},
-			{
-				"nome": "ID",
-				"valor": "PDVSYNC - ENVIAR ESTOQUE DISPONiVEL-{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "BODY"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "PDVSYNC - ENVIAR ESTOQUE DISPONiVEL"
-			},
-			{
-				"nome": "VALOR",
-				"valor":"ADICIONAR_INQUILINO"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			}
-		]
-	}
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": ""
+      },
+      {
+        "nome": "ID",
+        "valor": "PDVSYNC - ENVIAR ESTOQUE DISPONiVEL-{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "BODY"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "PDVSYNC - ENVIAR ESTOQUE DISPONiVEL"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_INQUILINO"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 16
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Número Inquilo"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/PDVSYNC - Enviar ICMS-{{ID_INQUILINO}}.json
+++ b/pdvsync/variaveis/PDVSYNC - Enviar ICMS-{{ID_INQUILINO}}.json
@@ -1,39 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": ""
-			},
-			{
-				"nome": "ID",
-				"valor": "PDVSYNC - ENVIAR ICMS-{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "BODY"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "PDVSYNC - ENVIAR ICMS"
-			},
-			{
-				"nome": "VALOR",
-				"valor":"ADICIONAR_INQUILINO"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			}
-		]
-	}
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": ""
+      },
+      {
+        "nome": "ID",
+        "valor": "PDVSYNC - ENVIAR ICMS-{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "BODY"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "PDVSYNC - ENVIAR ICMS"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_INQUILINO"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 18
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Número Inquilo"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/PDVSYNC - Enviar ICMS-{{MASTER_ID_PROPRIETARIO}}.json
+++ b/pdvsync/variaveis/PDVSYNC - Enviar ICMS-{{MASTER_ID_PROPRIETARIO}}.json
@@ -1,39 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": ""
-			},
-			{
-				"nome": "ID",
-				"valor": "PDVSYNC - ENVIAR ICMS-{{MASTER_ID_PROPRIETARIO}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{MASTER_ID_PROPRIETARIO}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "BODY"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "PDVSYNC - ENVIAR ICMS"
-			},
-			{
-				"nome": "VALOR",
-				"valor": "9999"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			}
-		]
-	}
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": ""
+      },
+      {
+        "nome": "ID",
+        "valor": "PDVSYNC - ENVIAR ICMS-{{MASTER_ID_PROPRIETARIO}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{MASTER_ID_PROPRIETARIO}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "BODY"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "PDVSYNC - ENVIAR ICMS"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "9999"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 19
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Número da filial ou 9999"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/PDVSYNC - Enviar Imposto Reforma-{{ID_INQUILINO}}.json
+++ b/pdvsync/variaveis/PDVSYNC - Enviar Imposto Reforma-{{ID_INQUILINO}}.json
@@ -1,40 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": ""
-			},
-			{
-				"nome": "ID",
-				"valor": "PDVSYNC - ENVIAR IMPOSTO REFORMA-{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "BODY"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "PDVSYNC - ENVIAR IMPOSTO REFORMA"
-			},
-			{
-				"nome": "VALOR",
-				"valor":"ADICIONAR_INQUILINO"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			}
-		]
-	}
-	
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": ""
+      },
+      {
+        "nome": "ID",
+        "valor": "PDVSYNC - ENVIAR IMPOSTO REFORMA-{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "BODY"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "PDVSYNC - ENVIAR IMPOSTO REFORMA"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_INQUILINO"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 20
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Número Inquilo"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/PDVSYNC - Enviar NCM Reforma Tributaria-{{ID_INQUILINO}}.json
+++ b/pdvsync/variaveis/PDVSYNC - Enviar NCM Reforma Tributaria-{{ID_INQUILINO}}.json
@@ -1,40 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": ""
-			},
-			{
-				"nome": "ID",
-				"valor": "PDVSYNC - ENVIAR NCM REFORMA TRIBUTARIA-{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "BODY"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "PDVSYNC - ENVIAR NCM REFORMA TRIBUTARIA"
-			},
-			{
-				"nome": "VALOR",
-				"valor":"ADICIONAR_INQUILINO"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			}
-		]
-	}
-	
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": ""
+      },
+      {
+        "nome": "ID",
+        "valor": "PDVSYNC - ENVIAR NCM REFORMA TRIBUTARIA-{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "BODY"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "PDVSYNC - ENVIAR NCM REFORMA TRIBUTARIA"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_INQUILINO"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 22
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Número Inquilo"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/PDVSYNC - Enviar Preco Embalagem-{{ID_INQUILINO}}.json
+++ b/pdvsync/variaveis/PDVSYNC - Enviar Preco Embalagem-{{ID_INQUILINO}}.json
@@ -1,39 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": ""
-			},
-			{
-				"nome": "ID",
-				"valor": "PDVSYNC - ENVIAR PRECO EMBALAGEM-{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "BODY"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "PDVSYNC - ENVIAR PRECO EMBALAGEM"
-			},
-			{
-				"nome": "VALOR",
-				"valor":"ADICIONAR_INQUILINO"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			}
-		]
-	}
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": ""
+      },
+      {
+        "nome": "ID",
+        "valor": "PDVSYNC - ENVIAR PRECO EMBALAGEM-{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "BODY"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "PDVSYNC - ENVIAR PRECO EMBALAGEM"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_INQUILINO"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 25
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Número Inquilo"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/PDVSYNC - Enviar Preco Fixo-{{ID_INQUILINO}}.json
+++ b/pdvsync/variaveis/PDVSYNC - Enviar Preco Fixo-{{ID_INQUILINO}}.json
@@ -1,39 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": ""
-			},
-			{
-				"nome": "ID",
-				"valor": "PDVSYNC - ENVIAR PRECO FIXO-{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "BODY"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "PDVSYNC - ENVIAR PRECO FIXO"
-			},
-			{
-				"nome": "VALOR",
-				"valor":"ADICIONAR_INQUILINO"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			}
-		]
-	}
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": ""
+      },
+      {
+        "nome": "ID",
+        "valor": "PDVSYNC - ENVIAR PRECO FIXO-{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "BODY"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "PDVSYNC - ENVIAR PRECO FIXO"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_INQUILINO"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 26
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Número Inquilo"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/PDVSYNC - Enviar Preco Produto-{{FILIAL_ID_PROPRIETARIO}}.json
+++ b/pdvsync/variaveis/PDVSYNC - Enviar Preco Produto-{{FILIAL_ID_PROPRIETARIO}}.json
@@ -1,39 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": ""
-			},
-			{
-				"nome": "ID",
-				"valor": "PDVSYNC - ENVIAR PRECO PRODUTO-{{FILIAL_ID_PROPRIETARIO}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{FILIAL_ID_PROPRIETARIO}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "BODY"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "PDVSYNC - ENVIAR PRECO PRODUTO"
-			},
-			{
-				"nome": "VALOR",
-				"valor": "ADICIONAR_FILIAL"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			}
-		]
-	}
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": ""
+      },
+      {
+        "nome": "ID",
+        "valor": "PDVSYNC - ENVIAR PRECO PRODUTO-{{FILIAL_ID_PROPRIETARIO}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{FILIAL_ID_PROPRIETARIO}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "BODY"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "PDVSYNC - ENVIAR PRECO PRODUTO"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_FILIAL"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 27
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Número da Filial"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/PDVSYNC - Enviar Preco Produto-{{ID_INQUILINO}}.json
+++ b/pdvsync/variaveis/PDVSYNC - Enviar Preco Produto-{{ID_INQUILINO}}.json
@@ -1,39 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": ""
-			},
-			{
-				"nome": "ID",
-				"valor": "PDVSYNC - ENVIAR PRECO PRODUTO-{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "BODY"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "PDVSYNC - ENVIAR PRECO PRODUTO"
-			},
-			{
-				"nome": "VALOR",
-				"valor":"ADICIONAR_INQUILINO"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			}
-		]
-	}
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": ""
+      },
+      {
+        "nome": "ID",
+        "valor": "PDVSYNC - ENVIAR PRECO PRODUTO-{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "BODY"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "PDVSYNC - ENVIAR PRECO PRODUTO"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_INQUILINO"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 28
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Número Inquilo"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/PDVSYNC - Enviar Preco Regiao-{{ID_INQUILINO}}.json
+++ b/pdvsync/variaveis/PDVSYNC - Enviar Preco Regiao-{{ID_INQUILINO}}.json
@@ -1,39 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": ""
-			},
-			{
-				"nome": "ID",
-				"valor": "PDVSYNC - ENVIAR PRECO REGIAO-{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "BODY"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "PDVSYNC - ENVIAR PRECO REGIAO"
-			},
-			{
-				"nome": "VALOR",
-				"valor":"ADICIONAR_INQUILINO"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			}
-		]
-	}
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": ""
+      },
+      {
+        "nome": "ID",
+        "valor": "PDVSYNC - ENVIAR PRECO REGIAO-{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "BODY"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "PDVSYNC - ENVIAR PRECO REGIAO"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_INQUILINO"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 29
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Número Inquilo"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/PDVSYNC - Enviar Produto Reforma Tribut-{{ID_INQUILINO}}.json
+++ b/pdvsync/variaveis/PDVSYNC - Enviar Produto Reforma Tribut-{{ID_INQUILINO}}.json
@@ -1,40 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": ""
-			},
-			{
-				"nome": "ID",
-				"valor": "PDVSYNC - ENVIAR PRODUTO REFORMA TRIBUT-{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "BODY"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "PDVSYNC - ENVIAR PRODUTO REFORMA TRIBUT"
-			},
-			{
-				"nome": "VALOR",
-				"valor":"ADICIONAR_INQUILINO"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			}
-		]
-	}
-	
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": ""
+      },
+      {
+        "nome": "ID",
+        "valor": "PDVSYNC - ENVIAR PRODUTO REFORMA TRIBUT-{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "BODY"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "PDVSYNC - ENVIAR PRODUTO REFORMA TRIBUT"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_INQUILINO"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 30
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Número Inquilo"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/PDVSYNC - Enviar compartilhamentos-{{ID_INQUILINO}}.json
+++ b/pdvsync/variaveis/PDVSYNC - Enviar compartilhamentos-{{ID_INQUILINO}}.json
@@ -1,39 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": ""
-			},
-			{
-				"nome": "ID",
-				"valor": "PDVSYNC - ENVIAR COMPARTILHAMENTOS-{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "BODY"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "PDVSYNC - ENVIAR COMPARTILHAMENTOS"
-			},
-			{
-				"nome": "VALOR",
-				"valor":"ADICIONAR_INQUILINO"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			}
-		]
-	}
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": ""
+      },
+      {
+        "nome": "ID",
+        "valor": "PDVSYNC - ENVIAR COMPARTILHAMENTOS-{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "BODY"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "PDVSYNC - ENVIAR COMPARTILHAMENTOS"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_INQUILINO"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 14
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Número Inquilo"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/PDVSYNC - Enviar formas de pgto-{{ID_INQUILINO}}.json
+++ b/pdvsync/variaveis/PDVSYNC - Enviar formas de pgto-{{ID_INQUILINO}}.json
@@ -1,39 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": ""
-			},
-			{
-				"nome": "ID",
-				"valor": "PDVSYNC - ENVIAR FORMAS DE PGTO-{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "BODY"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "PDVSYNC - ENVIAR FORMAS DE PGTO"
-			},
-			{
-				"nome": "VALOR",
-				"valor":"ADICIONAR_INQUILINO"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			}
-		]
-	}
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": ""
+      },
+      {
+        "nome": "ID",
+        "valor": "PDVSYNC - ENVIAR FORMAS DE PGTO-{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "BODY"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "PDVSYNC - ENVIAR FORMAS DE PGTO"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_INQUILINO"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 17
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Número Inquilo"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/PDVSYNC - Enviar lojas-{{ID_INQUILINO}}.json
+++ b/pdvsync/variaveis/PDVSYNC - Enviar lojas-{{ID_INQUILINO}}.json
@@ -1,39 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": ""
-			},
-			{
-				"nome": "ID",
-				"valor": "PDVSYNC - ENVIAR LOJAS-{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "BODY"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "PDVSYNC - ENVIAR LOJAS"
-			},
-			{
-				"nome": "VALOR",
-				"valor":"ADICIONAR_INQUILINO"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			}
-		]
-	}
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": ""
+      },
+      {
+        "nome": "ID",
+        "valor": "PDVSYNC - ENVIAR LOJAS-{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "BODY"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "PDVSYNC - ENVIAR LOJAS"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_INQUILINO"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 21
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Número Inquilo"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/PDVSYNC - Enviar planos de pgto-{{ID_INQUILINO}}.json
+++ b/pdvsync/variaveis/PDVSYNC - Enviar planos de pgto-{{ID_INQUILINO}}.json
@@ -1,39 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": ""
-			},
-			{
-				"nome": "ID",
-				"valor": "PDVSYNC - ENVIAR PLANOS DE PGTO-{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "BODY"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "PDVSYNC - ENVIAR PLANOS DE PGTO"
-			},
-			{
-				"nome": "VALOR",
-				"valor":"ADICIONAR_INQUILINO"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			}
-		]
-	}
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": ""
+      },
+      {
+        "nome": "ID",
+        "valor": "PDVSYNC - ENVIAR PLANOS DE PGTO-{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "BODY"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "PDVSYNC - ENVIAR PLANOS DE PGTO"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_INQUILINO"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 24
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Número Inquilo"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/PDVSYNC - RAC LoginPDVSync-{{PASSWORD}}.json
+++ b/pdvsync/variaveis/PDVSYNC - RAC LoginPDVSync-{{PASSWORD}}.json
@@ -1,39 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": "16-NOV-23"
-			},
-			{
-				"nome": "ID",
-				"valor": "PDVSYNC - RAC LOGINPDVSYNC-{{PASSWORD}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{PASSWORD}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "BODY"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "PDVSYNC - RAC LOGINPDVSYNC"
-			},
-			{
-				"nome": "VALOR",
-				"valor": "ADICIONAR_PASSWORD_RAC"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			}
-		]
-	}
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": "16-NOV-23"
+      },
+      {
+        "nome": "ID",
+        "valor": "PDVSYNC - RAC LOGINPDVSYNC-{{PASSWORD}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{PASSWORD}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "BODY"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "PDVSYNC - RAC LOGINPDVSYNC"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_PASSWORD_RAC"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 31
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Senha do RAC"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/PDVSYNC - RAC LoginPDVSync-{{URL_RAC_PDVSYNC}}.json
+++ b/pdvsync/variaveis/PDVSYNC - RAC LoginPDVSync-{{URL_RAC_PDVSYNC}}.json
@@ -1,39 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": ""
-			},
-			{
-				"nome": "ID",
-				"valor": "PDVSYNC - RAC LOGINPDVSYNC-{{URL_RAC_PDVSYNC}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{URL_RAC_PDVSYNC}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "BODY"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "PDVSYNC - RAC LOGINPDVSYNC"
-			},
-			{
-				"nome": "VALOR",
-				"valor": "ADICIONAR_URL"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			}
-		]
-	}
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": ""
+      },
+      {
+        "nome": "ID",
+        "valor": "PDVSYNC - RAC LOGINPDVSYNC-{{URL_RAC_PDVSYNC}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{URL_RAC_PDVSYNC}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "BODY"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "PDVSYNC - RAC LOGINPDVSYNC"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_URL"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 32
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Url do rac PDVSYNC"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/PDVSYNC - RAC LoginPDVSync-{{USERNAME}}.json
+++ b/pdvsync/variaveis/PDVSYNC - RAC LoginPDVSync-{{USERNAME}}.json
@@ -1,39 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": "16-NOV-23"
-			},
-			{
-				"nome": "ID",
-				"valor": "PDVSYNC - RAC LOGINPDVSYNC-{{USERNAME}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{USERNAME}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "BODY"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "PDVSYNC - RAC LOGINPDVSYNC"
-			},
-			{
-				"nome": "VALOR",
-				"valor": "ADICIONAR_USERNAME_RAC"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			}
-		]
-	}
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": "16-NOV-23"
+      },
+      {
+        "nome": "ID",
+        "valor": "PDVSYNC - RAC LOGINPDVSYNC-{{USERNAME}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{USERNAME}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "BODY"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "PDVSYNC - RAC LOGINPDVSYNC"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_USERNAME_RAC"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 33
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Nome do Usuário do RAC"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/PDVSYNC - Salvar Clientes-{{ID_INQUILINO}}.json
+++ b/pdvsync/variaveis/PDVSYNC - Salvar Clientes-{{ID_INQUILINO}}.json
@@ -1,39 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": ""
-			},
-			{
-				"nome": "ID",
-				"valor": "PDVSYNC - SALVAR CLIENTES-{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "BODY"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "PDVSYNC - SALVAR CLIENTES"
-			},
-			{
-				"nome": "VALOR",
-				"valor":"ADICIONAR_INQUILINO"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			}
-		]
-	}
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": ""
+      },
+      {
+        "nome": "ID",
+        "valor": "PDVSYNC - SALVAR CLIENTES-{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "BODY"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "PDVSYNC - SALVAR CLIENTES"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_INQUILINO"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 34
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Número Inquilo"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/PDVSYNC - Salvar Endereco Entrega Client-{{ID_INQUILINO}}.json
+++ b/pdvsync/variaveis/PDVSYNC - Salvar Endereco Entrega Client-{{ID_INQUILINO}}.json
@@ -1,39 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": ""
-			},
-			{
-				"nome": "ID",
-				"valor": "PDVSYNC - SALVAR ENDERECO ENTREGA CLIENT-{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "BODY"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "PDVSYNC - SALVAR ENDERECO ENTREGA CLIENT"
-			},
-			{
-				"nome": "VALOR",
-				"valor":"ADICIONAR_INQUILINO"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			}
-		]
-	}
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": ""
+      },
+      {
+        "nome": "ID",
+        "valor": "PDVSYNC - SALVAR ENDERECO ENTREGA CLIENT-{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "BODY"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "PDVSYNC - SALVAR ENDERECO ENTREGA CLIENT"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_INQUILINO"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 35
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Número Inquilo"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/PDVSYNC - Salvar Grupo Campanha Cliente-{{ID_INQUILINO}}.json
+++ b/pdvsync/variaveis/PDVSYNC - Salvar Grupo Campanha Cliente-{{ID_INQUILINO}}.json
@@ -1,39 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": ""
-			},
-			{
-				"nome": "ID",
-				"valor": "PDVSYNC - SALVAR GRUPO CAMPANHA CLIENTE-{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "BODY"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "PDVSYNC - SALVAR GRUPO CAMPANHA CLIENTE"
-			},
-			{
-				"nome": "VALOR",
-				"valor":"ADICIONAR_INQUILINO"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			}
-		]
-	}
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": ""
+      },
+      {
+        "nome": "ID",
+        "valor": "PDVSYNC - SALVAR GRUPO CAMPANHA CLIENTE-{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "BODY"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "PDVSYNC - SALVAR GRUPO CAMPANHA CLIENTE"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_INQUILINO"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 36
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Número Inquilo"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/PDVSYNC - Salvar Imposto NCM-{{ID_INQUILINO}}.json
+++ b/pdvsync/variaveis/PDVSYNC - Salvar Imposto NCM-{{ID_INQUILINO}}.json
@@ -1,39 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": ""
-			},
-			{
-				"nome": "ID",
-				"valor": "PDVSYNC - SALVAR IMPOSTO NCM-{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "BODY"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "PDVSYNC - SALVAR IMPOSTO NCM"
-			},
-			{
-				"nome": "VALOR",
-				"valor":"ADICIONAR_INQUILINO"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			}
-		]
-	}
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": ""
+      },
+      {
+        "nome": "ID",
+        "valor": "PDVSYNC - SALVAR IMPOSTO NCM-{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "BODY"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "PDVSYNC - SALVAR IMPOSTO NCM"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_INQUILINO"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 37
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Número Inquilo"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/PDVSYNC - Salvar Operadora-{{ID_INQUILINO}}.json
+++ b/pdvsync/variaveis/PDVSYNC - Salvar Operadora-{{ID_INQUILINO}}.json
@@ -1,39 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": ""
-			},
-			{
-				"nome": "ID",
-				"valor": "PDVSYNC - SALVAR OPERADORA-{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "BODY"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "PDVSYNC - SALVAR OPERADORA"
-			},
-			{
-				"nome": "VALOR",
-				"valor":"ADICIONAR_INQUILINO"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			}
-		]
-	}
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": ""
+      },
+      {
+        "nome": "ID",
+        "valor": "PDVSYNC - SALVAR OPERADORA-{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "BODY"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "PDVSYNC - SALVAR OPERADORA"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_INQUILINO"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 38
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Número Inquilo"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/PDVSYNC - Salvar Produto-{{FILIAL_ID_PROPRIETARIO}}.json
+++ b/pdvsync/variaveis/PDVSYNC - Salvar Produto-{{FILIAL_ID_PROPRIETARIO}}.json
@@ -1,39 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": ""
-			},
-			{
-				"nome": "ID",
-				"valor": "PDVSYNC - SALVAR PRODUTO-{{FILIAL_ID_PROPRIETARIO}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{FILIAL_ID_PROPRIETARIO}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "BODY"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "PDVSYNC - SALVAR PRODUTO"
-			},
-			{
-				"nome": "VALOR",
-				"valor": "ADICIONAR_FILIAL"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			}
-		]
-	}
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": ""
+      },
+      {
+        "nome": "ID",
+        "valor": "PDVSYNC - SALVAR PRODUTO-{{FILIAL_ID_PROPRIETARIO}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{FILIAL_ID_PROPRIETARIO}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "BODY"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "PDVSYNC - SALVAR PRODUTO"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_FILIAL"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 39
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Número da Filial"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/PDVSYNC - Salvar Produto-{{ID_INQUILINO}}.json
+++ b/pdvsync/variaveis/PDVSYNC - Salvar Produto-{{ID_INQUILINO}}.json
@@ -1,39 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": ""
-			},
-			{
-				"nome": "ID",
-				"valor": "PDVSYNC - SALVAR PRODUTO-{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "BODY"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "PDVSYNC - SALVAR PRODUTO"
-			},
-			{
-				"nome": "VALOR",
-				"valor":"ADICIONAR_INQUILINO"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			}
-		]
-	}
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": ""
+      },
+      {
+        "nome": "ID",
+        "valor": "PDVSYNC - SALVAR PRODUTO-{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "BODY"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "PDVSYNC - SALVAR PRODUTO"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_INQUILINO"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 40
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Número Inquilo"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/PDVSYNC - Salvar Profissional-{{ID_INQUILINO}}.json
+++ b/pdvsync/variaveis/PDVSYNC - Salvar Profissional-{{ID_INQUILINO}}.json
@@ -1,39 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": ""
-			},
-			{
-				"nome": "ID",
-				"valor": "PDVSYNC - SALVAR PROFISSIONAL-{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "BODY"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "PDVSYNC - SALVAR PROFISSIONAL"
-			},
-			{
-				"nome": "VALOR",
-				"valor":"ADICIONAR_INQUILINO"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			}
-		]
-	}
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": ""
+      },
+      {
+        "nome": "ID",
+        "valor": "PDVSYNC - SALVAR PROFISSIONAL-{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "BODY"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "PDVSYNC - SALVAR PROFISSIONAL"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_INQUILINO"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 41
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Número Inquilo"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/PDVSYNC - Salvar Ramo Atividade-{{ID_INQUILINO}}.json
+++ b/pdvsync/variaveis/PDVSYNC - Salvar Ramo Atividade-{{ID_INQUILINO}}.json
@@ -1,39 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": ""
-			},
-			{
-				"nome": "ID",
-				"valor": "PDVSYNC - SALVAR RAMO ATIVIDADE-{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "BODY"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "PDVSYNC - SALVAR RAMO ATIVIDADE"
-			},
-			{
-				"nome": "VALOR",
-				"valor":"ADICIONAR_INQUILINO"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			}
-		]
-	}
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": ""
+      },
+      {
+        "nome": "ID",
+        "valor": "PDVSYNC - SALVAR RAMO ATIVIDADE-{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "BODY"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "PDVSYNC - SALVAR RAMO ATIVIDADE"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_INQUILINO"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 42
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Número Inquilo"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/PDVSYNC - Salvar Regiao-{{ID_INQUILINO}}.json
+++ b/pdvsync/variaveis/PDVSYNC - Salvar Regiao-{{ID_INQUILINO}}.json
@@ -1,40 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": ""
-			},
-			{
-				"nome": "ID",
-				"valor": "PDVSYNC - SALVAR REGIAO-{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "BODY"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "PDVSYNC - SALVAR REGIAO"
-			},
-			{
-				"nome": "VALOR",
-				"valor":"ADICIONAR_INQUILINO"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			}
-		]
-	}
-	
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": ""
+      },
+      {
+        "nome": "ID",
+        "valor": "PDVSYNC - SALVAR REGIAO-{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "BODY"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "PDVSYNC - SALVAR REGIAO"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_INQUILINO"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 43
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Número Inquilo"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/PDVSYNC - Salvar Usuario Operador-{{ID_INQUILINO}}.json
+++ b/pdvsync/variaveis/PDVSYNC - Salvar Usuario Operador-{{ID_INQUILINO}}.json
@@ -1,39 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": ""
-			},
-			{
-				"nome": "ID",
-				"valor": "PDVSYNC - SALVAR USUARIO OPERADOR-{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "BODY"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "PDVSYNC - SALVAR USUARIO OPERADOR"
-			},
-			{
-				"nome": "VALOR",
-				"valor":"ADICIONAR_INQUILINO"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			}
-		]
-	}
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": ""
+      },
+      {
+        "nome": "ID",
+        "valor": "PDVSYNC - SALVAR USUARIO OPERADOR-{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "BODY"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "PDVSYNC - SALVAR USUARIO OPERADOR"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_INQUILINO"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 44
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Número Inquilo"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/WTA - Busca Registrar IP Inquilino-{{ID_INQUILINO}}.json
+++ b/pdvsync/variaveis/WTA - Busca Registrar IP Inquilino-{{ID_INQUILINO}}.json
@@ -1,39 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": "16-NOV-23"
-			},
-			{
-				"nome": "ID",
-				"valor": "WTA - BUSCA REGISTRAR IP INQUILINO-{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "BODY"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "WTA - BUSCA REGISTRAR IP INQUILINO"
-			},
-			{
-				"nome": "VALOR",
-				"valor":"ADICIONAR_INQUILINO"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			}
-		]
-	}
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": "16-NOV-23"
+      },
+      {
+        "nome": "ID",
+        "valor": "WTA - BUSCA REGISTRAR IP INQUILINO-{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "BODY"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "WTA - BUSCA REGISTRAR IP INQUILINO"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_INQUILINO"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 45
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Número Inquilo"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/WTA - Buscar Estoque-{{FILIAL}}.json
+++ b/pdvsync/variaveis/WTA - Buscar Estoque-{{FILIAL}}.json
@@ -1,42 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": ""
-			},
-			{
-				"nome": "ID",
-				"valor": "WTA - BUSCAR ESTOQUE-{{FILIAL}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{FILIAL}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "PARAMS"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "WTA - BUSCAR ESTOQUE"
-			},
-			{
-				"nome": "VALOR",
-				"valor": "ADICIONAR_FILIAL"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			},{
-                "nome": "VISIVELWIZARD",
-                "valor": "S"
-            }
-		]
-	}
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": ""
+      },
+      {
+        "nome": "ID",
+        "valor": "WTA - BUSCAR ESTOQUE-{{FILIAL}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{FILIAL}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "PARAMS"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "WTA - BUSCAR ESTOQUE"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_FILIAL"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 46
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Número da Filial"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/WTA - Buscar Filiais Compartilhamento-{{FILIAL}}.json
+++ b/pdvsync/variaveis/WTA - Buscar Filiais Compartilhamento-{{FILIAL}}.json
@@ -1,39 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": ""
-			},
-			{
-				"nome": "ID",
-				"valor": "WTA - BUSCAR FILIAIS COMPARTILHAMENTO-{{FILIAL}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{FILIAL}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "BODY"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "WTA - BUSCAR FILIAIS COMPARTILHAMENTO"
-			},
-			{
-				"nome": "VALOR",
-				"valor": "ADICIONAR_FILIAL"				
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			}
-		]
-	}
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": ""
+      },
+      {
+        "nome": "ID",
+        "valor": "WTA - BUSCAR FILIAIS COMPARTILHAMENTO-{{FILIAL}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{FILIAL}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "BODY"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "WTA - BUSCAR FILIAIS COMPARTILHAMENTO"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_FILIAL"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 47
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Número da Filial"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/WTA - Buscar Filiais Lojas-{{FILIAL}}.json
+++ b/pdvsync/variaveis/WTA - Buscar Filiais Lojas-{{FILIAL}}.json
@@ -1,39 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": ""
-			},
-			{
-				"nome": "ID",
-				"valor": "WTA - BUSCAR FILIAIS LOJAS-{{FILIAL}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{FILIAL}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "BODY"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "WTA - BUSCAR FILIAIS LOJAS"
-			},
-			{
-				"nome": "VALOR",
-				"valor": "ADICIONAR_FILIAL"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			}
-		]
-	}
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": ""
+      },
+      {
+        "nome": "ID",
+        "valor": "WTA - BUSCAR FILIAIS LOJAS-{{FILIAL}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{FILIAL}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "BODY"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "WTA - BUSCAR FILIAIS LOJAS"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_FILIAL"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 48
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Número da Filial"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/WTA - Buscar Imposto NCM PDV-{{FILIAL}}.json
+++ b/pdvsync/variaveis/WTA - Buscar Imposto NCM PDV-{{FILIAL}}.json
@@ -1,39 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": ""
-			},
-			{
-				"nome": "ID",
-				"valor": "WTA - BUSCAR IMPOSTO NCM PDV-{{}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{FILIAL}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "PARAMS"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "WTA - BUSCAR IMPOSTO NCM PDV"
-			},
-			{
-				"nome": "VALOR",
-				"valor": "ADICIONAR_FILIAL"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			}
-		]
-	}
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": ""
+      },
+      {
+        "nome": "ID",
+        "valor": "WTA - BUSCAR IMPOSTO NCM PDV-{{}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{FILIAL}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "PARAMS"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "WTA - BUSCAR IMPOSTO NCM PDV"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_FILIAL"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 49
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Número da Filial"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/WTA - Buscar Perfil PADRAO-{{ID_INQUILINO}}.json
+++ b/pdvsync/variaveis/WTA - Buscar Perfil PADRAO-{{ID_INQUILINO}}.json
@@ -1,39 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": ""
-			},
-			{
-				"nome": "ID",
-				"valor": "WTA - BUSCAR PERFIL PADRAO-{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "BODY"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "WTA - BUSCAR PERFIL PADRAO"
-			},
-			{
-				"nome": "VALOR",
-				"valor":"ADICIONAR_INQUILINO"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			}
-		]
-	}
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": ""
+      },
+      {
+        "nome": "ID",
+        "valor": "WTA - BUSCAR PERFIL PADRAO-{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "BODY"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "WTA - BUSCAR PERFIL PADRAO"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_INQUILINO"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 50
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Número Inquilo"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/WTA - Buscar Preco Embalagem-{{BRANCH_ID}}.json
+++ b/pdvsync/variaveis/WTA - Buscar Preco Embalagem-{{BRANCH_ID}}.json
@@ -1,39 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": ""
-			},
-			{
-				"nome": "ID",
-				"valor": "WTA - BUSCAR PRECO EMBALAGEM-{{BRANCH_ID}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{BRANCH_ID}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "PARAMS"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "WTA - BUSCAR PRECO EMBALAGEM"
-			},
-			{
-				"nome": "VALOR",
-				"valor": "ADICIONAR_FILIAL"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			}
-		]
-	}
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": ""
+      },
+      {
+        "nome": "ID",
+        "valor": "WTA - BUSCAR PRECO EMBALAGEM-{{BRANCH_ID}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{BRANCH_ID}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "PARAMS"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "WTA - BUSCAR PRECO EMBALAGEM"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_FILIAL"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 51
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Número da Filial"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/WTA - Buscar Preco Fixo-{{FILIAL}}.json
+++ b/pdvsync/variaveis/WTA - Buscar Preco Fixo-{{FILIAL}}.json
@@ -1,39 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": ""
-			},
-			{
-				"nome": "ID",
-				"valor": "WTA - BUSCAR PRECO FIXO-{{FILIAL}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{FILIAL}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "BODY"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "WTA - BUSCAR PRECO FIXO"
-			},
-			{
-				"nome": "VALOR",
-				"valor": "ADICIONAR_FILIAL"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			}
-		]
-	}
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": ""
+      },
+      {
+        "nome": "ID",
+        "valor": "WTA - BUSCAR PRECO FIXO-{{FILIAL}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{FILIAL}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "BODY"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "WTA - BUSCAR PRECO FIXO"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_FILIAL"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 52
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Número da Filial"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/WTA - Buscar Preco Fixo-{{NUMREGIAO}}.json
+++ b/pdvsync/variaveis/WTA - Buscar Preco Fixo-{{NUMREGIAO}}.json
@@ -1,39 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": ""
-			},
-			{
-				"nome": "ID",
-				"valor": "WTA - BUSCAR PRECO FIXO-{{NUMREGIAO}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{NUMREGIAO}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "BODY"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "WTA - BUSCAR PRECO FIXO"
-			},
-			{
-				"nome": "VALOR",
-				"valor": "ADICIONAR_REGIAO"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			}
-		]
-	}
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": ""
+      },
+      {
+        "nome": "ID",
+        "valor": "WTA - BUSCAR PRECO FIXO-{{NUMREGIAO}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{NUMREGIAO}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "BODY"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "WTA - BUSCAR PRECO FIXO"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_REGIAO"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 53
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Número da Região"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/WTA - Buscar Preco Produto-{{FILIAL}}.json
+++ b/pdvsync/variaveis/WTA - Buscar Preco Produto-{{FILIAL}}.json
@@ -1,43 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": ""
-			},
-			{
-				"nome": "ID",
-				"valor": "WTA - BUSCAR PRECO PRODUTO-{{FILIAL}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{FILIAL}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "PARAMS"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "WTA - BUSCAR PRECO PRODUTO"
-			},
-			{
-				"nome": "VALOR",
-				"valor": "ADICIONAR_FILIAL"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			},
-			{
-                "nome": "VISIVELWIZARD",
-                "valor": "S"
-            }
-		]
-	}
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": ""
+      },
+      {
+        "nome": "ID",
+        "valor": "WTA - BUSCAR PRECO PRODUTO-{{FILIAL}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{FILIAL}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "PARAMS"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "WTA - BUSCAR PRECO PRODUTO"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_FILIAL"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 54
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Número da Filial"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/WTA - Buscar Preco Regiao-{{BRANCH_ID}}.json
+++ b/pdvsync/variaveis/WTA - Buscar Preco Regiao-{{BRANCH_ID}}.json
@@ -1,39 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": ""
-			},
-			{
-				"nome": "ID",
-				"valor": "WTA - BUSCAR PRECO REGIAO-{{BRANCH_ID}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{BRANCH_ID}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "PARAMS"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "WTA - BUSCAR PRECO REGIAO"
-			},
-			{
-				"nome": "VALOR",
-				"valor": "ADICIONAR_FILIAL"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			}
-		]
-	}
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": ""
+      },
+      {
+        "nome": "ID",
+        "valor": "WTA - BUSCAR PRECO REGIAO-{{BRANCH_ID}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{BRANCH_ID}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "PARAMS"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "WTA - BUSCAR PRECO REGIAO"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_FILIAL"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 55
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Número da Filial"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/WTA - Buscar Produto PDV-{{FILIAL}}.json
+++ b/pdvsync/variaveis/WTA - Buscar Produto PDV-{{FILIAL}}.json
@@ -1,43 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": ""
-			},
-			{
-				"nome": "ID",
-				"valor": "WTA - BUSCAR PRODUTO PDV-{{FILIAL}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{FILIAL}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "PARAMS"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "WTA - BUSCAR PRODUTO PDV"
-			},
-			{
-				"nome": "VALOR",
-				"valor": "ADICIONAR_FILIAL"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			},
-			{
-                "nome": "VISIVELWIZARD",
-                "valor": "S"
-            }
-		]
-	}
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": ""
+      },
+      {
+        "nome": "ID",
+        "valor": "WTA - BUSCAR PRODUTO PDV-{{FILIAL}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{FILIAL}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "PARAMS"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "WTA - BUSCAR PRODUTO PDV"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_FILIAL"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 56
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Número da Filial"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/WTA - Buscar Regiao PDV-{{FILIAL}}.json
+++ b/pdvsync/variaveis/WTA - Buscar Regiao PDV-{{FILIAL}}.json
@@ -28,7 +28,7 @@
 			},
 			{
 				"nome": "VALOR",
-				"valor": "ADICIONAR_FILIAL"
+				"valor": "99"
 			},
 			{
 				"nome": "CODEMPALTER",

--- a/pdvsync/variaveis/WTA - Buscar status pedido-{{FILIAL}}.json
+++ b/pdvsync/variaveis/WTA - Buscar status pedido-{{FILIAL}}.json
@@ -1,39 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": ""
-			},
-			{
-				"nome": "ID",
-				"valor": "WTA - BUSCAR STATUS PEDIDO-{{FILIAL}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{FILIAL}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "BODY"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "WTA - BUSCAR STATUS PEDIDO"
-			},
-			{
-				"nome": "VALOR",
-				"valor": "ADICIONAR_FILIAL"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			}
-		]
-	}
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": ""
+      },
+      {
+        "nome": "ID",
+        "valor": "WTA - BUSCAR STATUS PEDIDO-{{FILIAL}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{FILIAL}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "BODY"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "WTA - BUSCAR STATUS PEDIDO"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_FILIAL"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 57
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Número da Filial"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/WTA - Consulta Profissional-{{ID_INQUILINO}}.json
+++ b/pdvsync/variaveis/WTA - Consulta Profissional-{{ID_INQUILINO}}.json
@@ -1,39 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": ""
-			},
-			{
-				"nome": "ID",
-				"valor": "WTA - Consulta Profissional-{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "BODY"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "WTA - Buscar Profissionais"
-			},
-			{
-				"nome": "VALOR",
-				"valor":"ADICIONAR_INQUILINO"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			}
-		]
-	}
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": ""
+      },
+      {
+        "nome": "ID",
+        "valor": "WTA - Consulta Profissional-{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "BODY"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "WTA - Buscar Profissionais"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_INQUILINO"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 58
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Número Inquilo"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/WTA - Consulta RCA-{{BRANCHID}}.json
+++ b/pdvsync/variaveis/WTA - Consulta RCA-{{BRANCHID}}.json
@@ -1,39 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": ""
-			},
-			{
-				"nome": "ID",
-				"valor": "WTA - Consulta RCA-{{BRANCHID}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{BRANCHID}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "BODY"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "WTA - CONSULTA RCA"
-			},
-			{
-				"nome": "VALOR",
-				"valor": "ADICIONAR_FILIAL"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			}
-		]
-	}
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": ""
+      },
+      {
+        "nome": "ID",
+        "valor": "WTA - Consulta RCA-{{BRANCHID}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{BRANCHID}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "BODY"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "WTA - CONSULTA RCA"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_FILIAL"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 59
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Número da Filial"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/WTA - Consulta RCA-{{ID_INQUILINO}}.json
+++ b/pdvsync/variaveis/WTA - Consulta RCA-{{ID_INQUILINO}}.json
@@ -1,39 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": ""
-			},
-			{
-				"nome": "ID",
-				"valor": "WTA - Consulta RCA-{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "BODY"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "WTA - CONSULTA RCA"
-			},
-			{
-				"nome": "VALOR",
-				"valor":"ADICIONAR_INQUILINO"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			}
-		]
-	}
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": ""
+      },
+      {
+        "nome": "ID",
+        "valor": "WTA - Consulta RCA-{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "BODY"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "WTA - CONSULTA RCA"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_INQUILINO"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 60
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Número Inquilo"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/WTA - Dados pagamento-{{ID_INQUILINO}}.json
+++ b/pdvsync/variaveis/WTA - Dados pagamento-{{ID_INQUILINO}}.json
@@ -1,39 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": ""
-			},
-			{
-				"nome": "ID",
-				"valor": "WTA - DADOS PAGAMENTO-{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "BODY"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "WTA - DADOS PAGAMENTO"
-			},
-			{
-				"nome": "VALOR",
-				"valor":"ADICIONAR_INQUILINO"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			}
-		]
-	}
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": ""
+      },
+      {
+        "nome": "ID",
+        "valor": "WTA - DADOS PAGAMENTO-{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "BODY"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "WTA - DADOS PAGAMENTO"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_INQUILINO"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 61
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Número Inquilo"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/WTA - LoginWTA-{{LOGIN}}.json
+++ b/pdvsync/variaveis/WTA - LoginWTA-{{LOGIN}}.json
@@ -1,39 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": ""
-			},
-			{
-				"nome": "ID",
-				"valor": "WTA - LOGINWTA-{{LOGIN}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{LOGIN}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "BODY"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "WTA - LOGINWTA"
-			},
-			{
-				"nome": "VALOR",
-				"valor": "ADICIONAR_LOGIN_WTA"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			}
-		]
-	}
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": ""
+      },
+      {
+        "nome": "ID",
+        "valor": "WTA - LOGINWTA-{{LOGIN}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{LOGIN}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "BODY"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "WTA - LOGINWTA"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_LOGIN_WTA"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 62
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Nome do Usuário Winthor"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/WTA - LoginWTA-{{SENHA}}.json
+++ b/pdvsync/variaveis/WTA - LoginWTA-{{SENHA}}.json
@@ -1,39 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": ""
-			},
-			{
-				"nome": "ID",
-				"valor": "WTA - LOGINWTA-{{SENHA}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{SENHA}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "BODY"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "WTA - LOGINWTA"
-			},
-			{
-				"nome": "VALOR",
-				"valor": "ADICIONAR_SENHA_WTA"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			}
-		]
-	}
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": ""
+      },
+      {
+        "nome": "ID",
+        "valor": "WTA - LOGINWTA-{{SENHA}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{SENHA}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "BODY"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "WTA - LOGINWTA"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_SENHA_WTA"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 63
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Senha do usuário do winthor em MD5"
+      }
+    ]
+  }
 }

--- a/pdvsync/variaveis/WTA - PDVSYNC Compartilhamento Master-{{ID_INQUILINO}}.json
+++ b/pdvsync/variaveis/WTA - PDVSYNC Compartilhamento Master-{{ID_INQUILINO}}.json
@@ -1,39 +1,51 @@
 {
-	"tabela": {
-		"nome": "PCINTEGRACAOVARIAVEIS",
-		"campos": [
-			{
-				"nome": "DTULTALTER",
-				"valor": ""
-			},
-			{
-				"nome": "ID",
-				"valor": "WTA - PDVSYNC COMPARTILHAMENTO MASTER-{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "CHAVE",
-				"valor": "{{ID_INQUILINO}}"
-			},
-			{
-				"nome": "TIPOCHAVE",
-				"valor": "BODY"
-			},
-			{
-				"nome": "TIPOVALOR",
-				"valor": "STRING"
-			},
-			{
-				"nome": "IDROTASERVICO",
-				"valor": "WTA - PDVSYNC COMPARTILHAMENTO MASTER"
-			},
-			{
-				"nome": "VALOR",
-				"valor":"ADICIONAR_INQUILINO"
-			},
-			{
-				"nome": "CODEMPALTER",
-				"valor": ""
-			}
-		]
-	}
+  "tabela": {
+    "nome": "PCINTEGRACAOVARIAVEIS",
+    "campos": [
+      {
+        "nome": "DTULTALTER",
+        "valor": ""
+      },
+      {
+        "nome": "ID",
+        "valor": "WTA - PDVSYNC COMPARTILHAMENTO MASTER-{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "CHAVE",
+        "valor": "{{ID_INQUILINO}}"
+      },
+      {
+        "nome": "TIPOCHAVE",
+        "valor": "BODY"
+      },
+      {
+        "nome": "TIPOVALOR",
+        "valor": "STRING"
+      },
+      {
+        "nome": "IDROTASERVICO",
+        "valor": "WTA - PDVSYNC COMPARTILHAMENTO MASTER"
+      },
+      {
+        "nome": "VALOR",
+        "valor": "ADICIONAR_INQUILINO"
+      },
+      {
+        "nome": "CODEMPALTER",
+        "valor": ""
+      },
+      {
+        "nome": "VISIVELWIZARD",
+        "valor": "S"
+      },
+      {
+        "nome": "ORDENACAOWIZARD",
+        "valor": 64
+      },
+      {
+        "nome": "DESCRICAOPARAM",
+        "valor": "Número Inquilo"
+      }
+    ]
+  }
 }


### PR DESCRIPTION
Contexto/Problema
No processo de instalação do layout do WSH referente à integração do tipo PDVSYNC, não havia variáveis preparadas para a nova uma interface parametrizada e ordenada de coleta de configurações obrigatórias durante o assistente de instalação (wizard).

Solução/Análise
Foram alterados os arquivos de variáveis da integração PDVSYNC e WTA, implementando o suporte a novas tags de configuração.

O novo comportamento incorpora as tags VISIVELWIZARD, ORDENACAOWIZARD e DESCRICAOPARAM diretamente nos arquivos estruturais.

Com essa entrega, no momento da instalação do layout do WSH, o wizard de instalação identificará essas tags e solicitará dinamicamente ao usuário o preenchimento desses parâmetros de forma estruturada, respeitando a ordenação especificada e mapeando as chaves necessárias de forma transparente.

O valor da alteração reside na redução de erros de configuração manual e na melhoria da experiência de setup da integração.

O teste só será possível, após a geração de tag de versão.